### PR TITLE
Fix for GH issue: https://github.com/gt-ospo/oss-project-explorer/issues48

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,24 +1,26 @@
 name: Build and Deploy to GitHub Pages
 
 on:
-  push:
-    branches: ['main']
+  pull_request:
+    types:
+      - closed
 
   workflow_dispatch:
 
 # Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
 # Allow one concurrent deployment
 concurrency:
-  group: 'pages'
+  group: 'deploy-${{ github.ref }}'
   cancel-in-progress: true
 
 jobs:
   deploy:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -36,7 +38,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Replace PAT
-        run: sed -i "s/OSPO_EXPLORER_TOKEN/$OSPO_EXPLORER_TOKEN/g" src/components/ProjectFormPage/ProjectForm.jsx
+        run: |
+          sed -i "s/OSPO_EXPLORER_TOKEN/$OSPO_EXPLORER_TOKEN/g" src/components/ProjectFormPage/ProjectForm.jsx
+          sed -i "s/OSPO_EXPLORER_TOKEN/$OSPO_EXPLORER_TOKEN/g" src/data/aggregateProjects.jsx      
+      - name: Aggregate Submission Files
+        run: node src/data/aggregateProjects.jsx
       - name: Build
         run: npm run build
       - name: Setup Pages

--- a/src/data/aggregateProjects.jsx
+++ b/src/data/aggregateProjects.jsx
@@ -1,0 +1,97 @@
+const { Octokit } = require("@octokit/core");
+
+const aggregateSubmissions = async (octokit) => {
+  const owner = "gt-ospo";
+  const repo = "oss-project-explorer";
+  const submissionsPath = "src/data/submissions";
+  const projectListPath = "src/data/project_list.json";
+
+  try {
+    // Fetch the list of files in the submissions folder
+    const submissionsResponse = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+      owner,
+      repo,
+      path: submissionsPath,
+    });
+
+    if (submissionsResponse.data.length === 0) {
+      console.log("No new submission files found.");
+      return;
+    }
+
+    // Fetch the current project_list.json file
+    const projectListResponse = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+      owner,
+      repo,
+      path: projectListPath,
+    });
+
+    const projectListContent = JSON.parse(Buffer.from(projectListResponse.data.content, 'base64').toString());
+    const projectListSha = projectListResponse.data.sha;
+
+    // Process each submission file
+    for (const file of submissionsResponse.data) {
+      if (file.type === "file" && file.name.endsWith(".json")) {
+        console.log(`Processing file: ${file.name}`);
+
+        // Fetch the content of the submission file
+        const fileResponse = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+          owner,
+          repo,
+          path: file.path,
+        });
+
+        const submissionContent = JSON.parse(Buffer.from(fileResponse.data.content, 'base64').toString());
+
+        // Append submission content to the project list
+        projectListContent.push(submissionContent);
+
+        // Delete the submission file
+        await octokit.request('DELETE /repos/{owner}/{repo}/contents/{path}', {
+          owner,
+          repo,
+          path: file.path,
+          message: `Processed and removed submission file: ${file.name}`,
+          sha: fileResponse.data.sha,
+        });
+
+        console.log(`Successfully processed and removed file: ${file.name}`);
+      }
+    }
+
+    // Update the project_list.json file
+    const updatedContent = Buffer.from(JSON.stringify(projectListContent, null, 2)).toString('base64');
+    await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+      owner,
+      repo,
+      path: projectListPath,
+      message: "Updated project_list.json with new submissions",
+      content: updatedContent,
+      sha: projectListSha,
+    });
+
+    console.log("Aggregation completed successfully.");
+  } catch (error) {
+    console.error("Unexpected error:", error.response?.data || error.message);
+    throw error;
+  }
+};
+
+// Initialize Octokit
+const octokit = new Octokit({
+    auth: "OSPO_EXPLORER_TOKEN",
+});
+
+// Run the aggregation script
+(async () => {
+  try {
+    await aggregateSubmissions(octokit);
+  } catch (error) {
+    if (error.status === 404) {
+      console.error("Submissions folder does not exist. Skipping aggregation.");
+    } else {
+      console.error("Unexpected error during aggregation:", error);
+      process.exit(1); // Exit with a failure code for CI/CD
+    }
+  }
+})();


### PR DESCRIPTION
Fixes problem with conflicts for similar PRs that are open at the same time.

## Repo Setting Changes Needed (In case these aren't set yet)
- Under the repo's settings in the "Actions" tab, will need to set "Workflow permissions" to "Read and write permissions".
- In the "Environments" tab, set "Deployment branches and tags" to "Protected branches only" while still having all branches being allows to deploy. 


## Changes
**pages-deploy.yml**
- GH action only runs when a PR is merged into main, not on git push into main
- Changed workflow run concurrency group to use github.ref to prevent concurrent workflow run locks
- Added step to run aggregateProjects.jsx

**projectForm.jsx:**
- Creates unique file per project submission under src/data/submissions folder that will be used for aggregation

**aggregateProjects.jsx**
- New task that only runs on GH Pages deployment.
- Consolidates all the project submission files in submissions folder and adds them to the project_list.json file.
- Deletes the submission files after